### PR TITLE
Import dashboard from url or grafana.com public ID + integration tests

### DIFF
--- a/tests/integration/targets/grafana_dashboard/aliases
+++ b/tests/integration/targets/grafana_dashboard/aliases
@@ -1,0 +1,1 @@
+shippable/posix/group1

--- a/tests/integration/targets/grafana_dashboard/files/dashboard.json
+++ b/tests/integration/targets/grafana_dashboard/files/dashboard.json
@@ -1,0 +1,85 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "id": 11,
+    "links": [],
+    "panels": [
+      {
+        "content": "\n# Title\n\nFor markdown syntax help: [commonmark.org/help](https://commonmark.org/help/)\n\n\n\n",
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 2,
+        "mode": "markdown",
+        "options": {},
+        "targets": [
+          {
+            "expr": "",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "refId": "A"
+          }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Panel Title",
+        "type": "text"
+      }
+    ],
+    "schemaVersion": 18,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "",
+    "title": "test",
+    "uid": "9ZlJIhhWk",
+    "version": 7
+  }

--- a/tests/integration/targets/grafana_dashboard/meta/main.yml
+++ b/tests/integration/targets/grafana_dashboard/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_grafana

--- a/tests/integration/targets/grafana_dashboard/tasks/dashboard-from-file.yml
+++ b/tests/integration/targets/grafana_dashboard/tasks/dashboard-from-file.yml
@@ -1,0 +1,44 @@
+---
+- name: copy dashboard file
+  copy:
+    src: "files/dashboard.json"
+    dest: "/tmp/dashboard.json"
+
+
+- name: Check import grafana dashboard from file
+  grafana_dashboard:
+    grafana_url: "http://127.0.0.1:3000"
+    grafana_user: "admin"
+    grafana_password: "admin"
+    state: present
+    message: Updated by ansible
+    path: /tmp/dashboard.json
+    overwrite: true
+  register: result
+
+- debug:
+    var: result
+
+- assert:
+    that:
+      - "result.changed == true"
+      - "result.msg == 'Dashboard test created'"
+
+- name: Check import grafana dashboard from file idempotency
+  grafana_dashboard:
+    grafana_url: "http://127.0.0.1:3000"
+    grafana_user: "admin"
+    grafana_password: "admin"
+    state: present
+    message: Updated by ansible
+    path: /tmp/dashboard.json
+    overwrite: true
+  register: result
+
+- debug:
+    var: result
+
+- assert:
+    that:
+      - "result.changed == false"
+      - "result.msg == 'Dashboard test unchanged.'"

--- a/tests/integration/targets/grafana_dashboard/tasks/dashboard-from-id.yml
+++ b/tests/integration/targets/grafana_dashboard/tasks/dashboard-from-id.yml
@@ -1,0 +1,40 @@
+---
+- name: Check import grafana dashboard from id
+  grafana_dashboard:
+    grafana_url: "http://127.0.0.1:3000"
+    grafana_user: "admin"
+    grafana_password: "admin"
+    state: present
+    message: Updated by ansible
+    dashboard_id: "6098"
+    dashboard_revision: "1"
+    overwrite: true
+  register: result
+
+- debug:
+    var: result
+
+- assert:
+    that:
+      - "result.changed == true"
+      - "result.msg == 'Dashboard Zabbix Host Status created'"
+
+- name: Check import grafana dashboard from id idempotency
+  grafana_dashboard:
+    grafana_url: "http://127.0.0.1:3000"
+    grafana_user: "admin"
+    grafana_password: "admin"
+    state: present
+    message: Updated by ansible
+    dashboard_id: "6098"
+    dashboard_revision: "1"
+    overwrite: true
+  register: result
+
+- debug:
+    var: result
+
+- assert:
+    that:
+      - "result.changed == false"
+      - "result.msg == 'Dashboard Zabbix Host Status unchanged.'"

--- a/tests/integration/targets/grafana_dashboard/tasks/dashboard-from-url.yml
+++ b/tests/integration/targets/grafana_dashboard/tasks/dashboard-from-url.yml
@@ -1,0 +1,39 @@
+---
+
+- name: Check import grafana dashboard from url
+  grafana_dashboard:
+    grafana_url: "http://127.0.0.1:3000"
+    grafana_user: "admin"
+    grafana_password: "admin"
+    state: present
+    message: Updated by ansible
+    dashboard_url: https://grafana.com/api/dashboards/6098/revisions/1/download
+    overwrite: true
+  register: result
+
+- debug:
+    var: result
+
+- assert:
+    that:
+      - "result.changed == true"
+      - "result.msg == 'Dashboard Zabbix Host Status created'"
+
+- name: Check import grafana dashboard from url idempotency
+  grafana_dashboard:
+    grafana_url: "http://127.0.0.1:3000"
+    grafana_user: "admin"
+    grafana_password: "admin"
+    state: present
+    message: Updated by ansible
+    dashboard_url: https://grafana.com/api/dashboards/6098/revisions/1/download
+    overwrite: true
+  register: result
+
+- debug:
+    var: result
+
+- assert:
+    that:
+      - "result.changed == false"
+      - "result.msg == 'Dashboard Zabbix Host Status unchanged.'"

--- a/tests/integration/targets/grafana_dashboard/tasks/delete-dashboard.yml
+++ b/tests/integration/targets/grafana_dashboard/tasks/delete-dashboard.yml
@@ -1,0 +1,16 @@
+- name: Check delete dashboard is working
+  grafana_dashboard:
+    grafana_url: "http://127.0.0.1:3000"
+    grafana_user: "admin"
+    grafana_password: "admin"
+    state: absent
+    uid: "{{ result.uid }}"
+  register: result
+
+- debug:
+    var: result
+
+- assert:
+    that:
+      - "result.changed == true"
+      - "result.msg == 'Dashboard {{ result.uid }} deleted'"

--- a/tests/integration/targets/grafana_dashboard/tasks/main.yml
+++ b/tests/integration/targets/grafana_dashboard/tasks/main.yml
@@ -1,0 +1,8 @@
+- block:
+  - include: dashboard-from-url.yml
+  - include: delete-dashboard.yml
+  - include: dashboard-from-id.yml
+  - include: dashboard-from-file.yml
+  when:
+    - ansible_distribution == 'Ubuntu'
+    - ansible_distribution_release != 'trusty'


### PR DESCRIPTION
##### SUMMARY
Same PR I made on the ansible repo : https://github.com/ansible/ansible/pull/64097

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
grafana_dashboard.py

##### ADDITIONAL INFORMATION
The `path` now have a `dashboard_url` alias and accept a HTTP url.
There is also a new `dashboard_id` parameter to import dashboard from grafana.com public dashboard ID.
Example :

    - name: Import Grafana dashboard Zabbix
      grafana_dashboard:
        grafana_url: http://grafana.company.com
        grafana_api_key: "{{ grafana_api_key }}"
        folder: zabbix
        dashboard_id: 6098

    - name: Import Grafana dashboard zabbix
      grafana_dashboard:
        grafana_url: http://grafana.company.com
        grafana_api_key: "{{ grafana_api_key }}"
        folder: zabbix
        dashboard_url: https://grafana.com/api/dashboards/6098/revisions/1/download

Related Issues / pulls :
https://github.com/ansible/ansible/issues/52636
https://github.com/ansible/ansible/pull/61716