### PR TITLE
CI to use ansible-minimal

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -16,14 +16,8 @@ jobs:
         with:
           python-version: 3.6
 
-      - name: HACK download ansible
-        run: git clone https://github.com/ansible-collection-migration/ansible-minimal.git
-
-      - name: HACK remove broken symlinks
-        run: find ansible-minimal -type l ! -exec test -e {} \; -print | xargs rm -f
-
-      - name: HACK Install ansible-minimal@devel
-        run: pip install -e ./ansible-minimal/
+      - name: Install ansible-minimal
+        run: pip install git+https://github.com/ansible-collection-migration/ansible-minimal.git --disable-pip-version-check
 
       - name: Run sanity tests
         run: ansible-test sanity --docker -v --color --python 3.6
@@ -41,15 +35,9 @@ jobs:
         with:
           python-version: 3.6
 
-      - name: HACK download ansible
-        run: git clone https://github.com/ansible-collection-migration/ansible-minimal.git
-
-      - name: HACK remove broken symlinks
-        run: find ansible-minimal -type l ! -exec test -e {} \; -print | xargs rm -f
-
-      - name: HACK Install ansible-minimal@devel
-        run: pip install -e ./ansible-minimal/
-
+      - name: Install ansible-minimal
+        run: pip install git+https://github.com/ansible-collection-migration/ansible-minimal.git --disable-pip-version-check
+        
       - name: Run unit tests
         run: ansible-test units --docker -v --color --python 3.6
 
@@ -69,14 +57,8 @@ jobs:
         with:
           python-version: ${{ matrix.python_version }}
 
-      - name: HACK download ansible
-        run: git clone https://github.com/ansible-collection-migration/ansible-minimal.git
-
-      - name: HACK remove broken symlinks
-        run: find ansible-minimal -type l ! -exec test -e {} \; -print | xargs rm -f
-
-      - name: HACK Install ansible-minimal@devel
-        run: pip install -e ./ansible-minimal/
+      - name: Install ansible-minimal
+        run: pip install git+https://github.com/ansible-collection-migration/ansible-minimal.git --disable-pip-version-check
 
       - name: Run integration tests on Python ${{ matrix.python_version }}
         run: ansible-test integration --docker -v --color --retry-on-error --python ${{ matrix.python_version }}

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -16,8 +16,14 @@ jobs:
         with:
           python-version: 3.6
 
-      - name: Install Ansible 2.9.1
-        run: pip install ansible==2.9.1 --disable-pip-version-check
+      - name: HACK download ansible
+        run: git clone https://github.com/ansible-collection-migration/ansible-minimal.git
+
+      - name: HACK remove broken symlinks
+        run: find ansible-minimal -type l ! -exec test -e {} \; -print | xargs rm -f
+
+      - name: HACK Install ansible-minimal@devel
+        run: pip install -e ./ansible-minimal/
 
       - name: Run sanity tests
         run: ansible-test sanity --docker -v --color --python 3.6
@@ -35,8 +41,14 @@ jobs:
         with:
           python-version: 3.6
 
-      - name: Install Ansible 2.9.1
-        run: pip install ansible==2.9.1 --disable-pip-version-check
+      - name: HACK download ansible
+        run: git clone https://github.com/ansible-collection-migration/ansible-minimal.git
+
+      - name: HACK remove broken symlinks
+        run: find ansible-minimal -type l ! -exec test -e {} \; -print | xargs rm -f
+
+      - name: HACK Install ansible-minimal@devel
+        run: pip install -e ./ansible-minimal/
 
       - name: Run unit tests
         run: ansible-test units --docker -v --color --python 3.6
@@ -57,8 +69,14 @@ jobs:
         with:
           python-version: ${{ matrix.python_version }}
 
-      - name: Install Ansible 2.9.1
-        run: pip install ansible==2.9.1 --disable-pip-version-check
+      - name: HACK download ansible
+        run: git clone https://github.com/ansible-collection-migration/ansible-minimal.git
+
+      - name: HACK remove broken symlinks
+        run: find ansible-minimal -type l ! -exec test -e {} \; -print | xargs rm -f
+
+      - name: HACK Install ansible-minimal@devel
+        run: pip install -e ./ansible-minimal/
 
       - name: Run integration tests on Python ${{ matrix.python_version }}
         run: ansible-test integration --docker -v --color --retry-on-error --python ${{ matrix.python_version }}


### PR DESCRIPTION
##### SUMMARY

By the time Ansible 2.10 has been released ansible/ansible will have been reduced to include only a very [small set of plugins](https://github.com/ansible-community/collection_migration/tree/master/scenarios/minimal) known as `ansible-minimal`

We should start running tests against this reduced set to ensure we don't have dependencies on anything else.

