### PR TITLE
grafana_dashboard: state isn't required as we have a default

### DIFF
--- a/plugins/modules/grafana_dashboard.py
+++ b/plugins/modules/grafana_dashboard.py
@@ -57,7 +57,6 @@ options:
   state:
     description:
       - State of the dashboard.
-    required: true
     choices: [ absent, export, present ]
     default: present
   slug:


### PR DESCRIPTION
grafana_dashboard: state has a default, therefore we don't require end-users authors to explicitly set it in the playbooks