### PR TITLE
ds_type is required in spec

### DIFF
--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -643,7 +643,7 @@ def main():
                               'mysql',
                               'postgres',
                               'cloudwatch',
-                              'alexanderzobnin-zabbix-datasource']),
+                              'alexanderzobnin-zabbix-datasource'], required=True),
         url=dict(required=True, type='str', aliases=['ds_url']),
         access=dict(default='proxy', choices=['proxy', 'direct']),
         grafana_api_key=dict(type='str', no_log=True),


### PR DESCRIPTION
##### SUMMARY
Grafana datasource module : 
`ds_type` parameter was marqued required in documentation, but not in specs.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
grafana-datasources.py

Related : https://github.com/gundalow-collections/grafana/pull/15

